### PR TITLE
Fix install script clone directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,10 +8,10 @@ echo "⚙️ Installing dependencies..."
 sudo apt install -y python3 python3-pip git
 
 echo "📥 Cloning repo..."
-if [ ! -d "bot-depoly" ]; then
-  git clone https://github.com/rayray6486/bot-depoly.git
+if [ ! -d "bot-deploy" ]; then
+  git clone https://github.com/rayray6486/bot-deploy.git
 fi
-cd bot-depoly
+cd bot-deploy
 
 echo "📦 Installing Python packages..."
 pip3 install -r requirements.txt


### PR DESCRIPTION
## Summary
- correct the installer to clone the bot-deploy repository into a matching directory
- update the directory change step to match the cloned folder name

## Testing
- bash install.sh (fails earlier on apt update in sandbox environment)


------
https://chatgpt.com/codex/tasks/task_e_68d065bf023c832087f209bd7c39d741